### PR TITLE
Validate overlapping TimeSlots

### DIFF
--- a/src/main/java/com/pontificia/remashorario/modules/TimeSlot/TimeSlotEntity.java
+++ b/src/main/java/com/pontificia/remashorario/modules/TimeSlot/TimeSlotEntity.java
@@ -11,7 +11,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "time_slot")
+@Table(name = "time_slot",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"start_time", "end_time"}))
 @Getter
 @Setter
 public class TimeSlotEntity extends BaseEntity {

--- a/src/main/java/com/pontificia/remashorario/modules/TimeSlot/TimeSlotRepository.java
+++ b/src/main/java/com/pontificia/remashorario/modules/TimeSlot/TimeSlotRepository.java
@@ -13,4 +13,9 @@ import java.util.UUID;
 @Repository
 public interface TimeSlotRepository extends JpaRepository<TimeSlotEntity, UUID> {
 
+    Optional<TimeSlotEntity> findByStartTimeAndEndTime(LocalTime startTime, LocalTime endTime);
+
+    @Query("SELECT ts FROM TimeSlotEntity ts WHERE ts.startTime < :endTime AND ts.endTime > :startTime")
+    List<TimeSlotEntity> findOverlapping(@Param("startTime") LocalTime startTime,
+                                         @Param("endTime") LocalTime endTime);
 }


### PR DESCRIPTION
## Summary
- enforce unique constraint on `start_time` + `end_time`
- expose overlap/duplicate queries for `TimeSlotRepository`
- validate overlaps in `TimeSlotService` when creating or updating slots

## Testing
- `./gradlew test --no-daemon` *(fails: could not download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_b_683cc38fb0008330b779123523deaeb5