### PR TITLE
Add Period entity and link to scheduling

### DIFF
--- a/src/main/java/com/pontificia/remashorario/modules/classSession/ClassSessionEntity.java
+++ b/src/main/java/com/pontificia/remashorario/modules/classSession/ClassSessionEntity.java
@@ -6,6 +6,7 @@ import com.pontificia.remashorario.modules.studentGroup.StudentGroupEntity;
 import com.pontificia.remashorario.modules.teacher.TeacherEntity;
 import com.pontificia.remashorario.modules.teachingHour.TeachingHourEntity;
 import com.pontificia.remashorario.modules.teachingType.TeachingTypeEntity;
+import com.pontificia.remashorario.modules.period.PeriodEntity;
 import com.pontificia.remashorario.utils.abstractBase.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -36,6 +37,10 @@ public class ClassSessionEntity extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "learning_space_id", nullable = false)
     private LearningSpaceEntity learningSpace;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "period_id", nullable = false)
+    private PeriodEntity period;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/pontificia/remashorario/modules/classSession/ClassSessionService.java
+++ b/src/main/java/com/pontificia/remashorario/modules/classSession/ClassSessionService.java
@@ -111,6 +111,7 @@ public class ClassSessionService extends BaseService<ClassSessionEntity> {
         // Crear y guardar
         ClassSessionEntity session = classSessionMapper.toEntity(
                 dto, studentGroup, course, teacher, learningSpace, sessionType, teachingHours);
+        session.setPeriod(studentGroup.getPeriod());
         ClassSessionEntity savedSession = save(session);
 
         return classSessionMapper.toResponseDTO(savedSession);
@@ -139,6 +140,7 @@ public class ClassSessionService extends BaseService<ClassSessionEntity> {
         // Actualizar
         classSessionMapper.updateEntityFromDTO(
                 session, dto, studentGroup, course, teacher, learningSpace, sessionType, teachingHours);
+        session.setPeriod(studentGroup.getPeriod());
         ClassSessionEntity updatedSession = save(session);
 
         return classSessionMapper.toResponseDTO(updatedSession);

--- a/src/main/java/com/pontificia/remashorario/modules/period/PeriodController.java
+++ b/src/main/java/com/pontificia/remashorario/modules/period/PeriodController.java
@@ -1,0 +1,49 @@
+package com.pontificia.remashorario.modules.period;
+
+import com.pontificia.remashorario.config.ApiResponse;
+import com.pontificia.remashorario.modules.period.dto.PeriodRequestDTO;
+import com.pontificia.remashorario.modules.period.dto.PeriodResponseDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/protected/periods")
+@RequiredArgsConstructor
+public class PeriodController {
+
+    private final PeriodService periodService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PeriodResponseDTO>>> getAllPeriods() {
+        return ResponseEntity.ok(ApiResponse.success(periodService.getAllPeriods(), "Periodos recuperados con éxito"));
+    }
+
+    @GetMapping("/{uuid}")
+    public ResponseEntity<ApiResponse<PeriodResponseDTO>> getPeriod(@PathVariable UUID uuid) {
+        return ResponseEntity.ok(ApiResponse.success(periodService.getPeriodById(uuid), "Periodo recuperado con éxito"));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<PeriodResponseDTO>> createPeriod(@Valid @RequestBody PeriodRequestDTO dto) {
+        PeriodResponseDTO created = periodService.createPeriod(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(created, "Periodo creado con éxito"));
+    }
+
+    @PutMapping("/{uuid}")
+    public ResponseEntity<ApiResponse<PeriodResponseDTO>> updatePeriod(@PathVariable UUID uuid, @Valid @RequestBody PeriodRequestDTO dto) {
+        PeriodResponseDTO updated = periodService.updatePeriod(uuid, dto);
+        return ResponseEntity.ok(ApiResponse.success(updated, "Periodo actualizado con éxito"));
+    }
+
+    @DeleteMapping("/{uuid}")
+    public ResponseEntity<ApiResponse<Void>> deletePeriod(@PathVariable UUID uuid) {
+        periodService.deletePeriod(uuid);
+        return ResponseEntity.ok(ApiResponse.success(null, "Periodo eliminado con éxito"));
+    }
+}

--- a/src/main/java/com/pontificia/remashorario/modules/period/PeriodEntity.java
+++ b/src/main/java/com/pontificia/remashorario/modules/period/PeriodEntity.java
@@ -1,0 +1,26 @@
+package com.pontificia.remashorario.modules.period;
+
+import com.pontificia.remashorario.utils.abstractBase.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "period")
+@Getter
+@Setter
+public class PeriodEntity extends BaseEntity {
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String name;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+}

--- a/src/main/java/com/pontificia/remashorario/modules/period/PeriodRepository.java
+++ b/src/main/java/com/pontificia/remashorario/modules/period/PeriodRepository.java
@@ -1,0 +1,9 @@
+package com.pontificia.remashorario.modules.period;
+
+import com.pontificia.remashorario.utils.abstractBase.BaseRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PeriodRepository extends BaseRepository<PeriodEntity> {
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/pontificia/remashorario/modules/period/PeriodService.java
+++ b/src/main/java/com/pontificia/remashorario/modules/period/PeriodService.java
@@ -1,0 +1,62 @@
+package com.pontificia.remashorario.modules.period;
+
+import com.pontificia.remashorario.modules.period.dto.PeriodRequestDTO;
+import com.pontificia.remashorario.modules.period.dto.PeriodResponseDTO;
+import com.pontificia.remashorario.modules.period.mapper.PeriodMapper;
+import com.pontificia.remashorario.utils.abstractBase.BaseService;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class PeriodService extends BaseService<PeriodEntity> {
+
+    private final PeriodRepository periodRepository;
+    private final PeriodMapper periodMapper;
+
+    public PeriodService(PeriodRepository periodRepository, PeriodMapper periodMapper) {
+        super(periodRepository);
+        this.periodRepository = periodRepository;
+        this.periodMapper = periodMapper;
+    }
+
+    public List<PeriodResponseDTO> getAllPeriods() {
+        return periodMapper.toResponseDTOList(findAll());
+    }
+
+    public PeriodResponseDTO getPeriodById(UUID uuid) {
+        return periodMapper.toResponseDTO(findPeriodOrThrow(uuid));
+    }
+
+    @Transactional
+    public PeriodResponseDTO createPeriod(PeriodRequestDTO dto) {
+        if (periodRepository.existsByName(dto.getName())) {
+            throw new IllegalArgumentException("Ya existe un periodo con ese nombre");
+        }
+        PeriodEntity entity = periodMapper.toEntity(dto);
+        return periodMapper.toResponseDTO(save(entity));
+    }
+
+    @Transactional
+    public PeriodResponseDTO updatePeriod(UUID uuid, PeriodRequestDTO dto) {
+        PeriodEntity period = findPeriodOrThrow(uuid);
+        if (!period.getName().equals(dto.getName()) && periodRepository.existsByName(dto.getName())) {
+            throw new IllegalArgumentException("Ya existe otro periodo con ese nombre");
+        }
+        periodMapper.updateEntityFromDTO(period, dto);
+        return periodMapper.toResponseDTO(save(period));
+    }
+
+    @Transactional
+    public void deletePeriod(UUID uuid) {
+        PeriodEntity period = findPeriodOrThrow(uuid);
+        deleteById(period.getUuid());
+    }
+
+    public PeriodEntity findPeriodOrThrow(UUID uuid) {
+        return findById(uuid).orElseThrow(() -> new EntityNotFoundException("Periodo no encontrado con ID: " + uuid));
+    }
+}

--- a/src/main/java/com/pontificia/remashorario/modules/period/dto/PeriodRequestDTO.java
+++ b/src/main/java/com/pontificia/remashorario/modules/period/dto/PeriodRequestDTO.java
@@ -1,0 +1,21 @@
+package com.pontificia.remashorario.modules.period.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class PeriodRequestDTO {
+    @NotBlank(message = "El nombre del periodo es obligatorio")
+    private String name;
+
+    @NotNull(message = "La fecha de inicio es obligatoria")
+    private LocalDate startDate;
+
+    @NotNull(message = "La fecha de fin es obligatoria")
+    private LocalDate endDate;
+}

--- a/src/main/java/com/pontificia/remashorario/modules/period/dto/PeriodResponseDTO.java
+++ b/src/main/java/com/pontificia/remashorario/modules/period/dto/PeriodResponseDTO.java
@@ -1,0 +1,18 @@
+package com.pontificia.remashorario.modules.period.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+public class PeriodResponseDTO {
+    private UUID uuid;
+    private String name;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/com/pontificia/remashorario/modules/period/mapper/PeriodMapper.java
+++ b/src/main/java/com/pontificia/remashorario/modules/period/mapper/PeriodMapper.java
@@ -1,0 +1,45 @@
+package com.pontificia.remashorario.modules.period.mapper;
+
+import com.pontificia.remashorario.modules.period.PeriodEntity;
+import com.pontificia.remashorario.modules.period.dto.PeriodRequestDTO;
+import com.pontificia.remashorario.modules.period.dto.PeriodResponseDTO;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class PeriodMapper {
+
+    public PeriodResponseDTO toResponseDTO(PeriodEntity entity) {
+        if (entity == null) return null;
+        return PeriodResponseDTO.builder()
+                .uuid(entity.getUuid())
+                .name(entity.getName())
+                .startDate(entity.getStartDate())
+                .endDate(entity.getEndDate())
+                .build();
+    }
+
+    public List<PeriodResponseDTO> toResponseDTOList(List<PeriodEntity> entities) {
+        return entities.stream()
+                .map(this::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    public PeriodEntity toEntity(PeriodRequestDTO dto) {
+        if (dto == null) return null;
+        PeriodEntity entity = new PeriodEntity();
+        entity.setName(dto.getName());
+        entity.setStartDate(dto.getStartDate());
+        entity.setEndDate(dto.getEndDate());
+        return entity;
+    }
+
+    public void updateEntityFromDTO(PeriodEntity entity, PeriodRequestDTO dto) {
+        if (entity == null || dto == null) return;
+        entity.setName(dto.getName());
+        entity.setStartDate(dto.getStartDate());
+        entity.setEndDate(dto.getEndDate());
+    }
+}

--- a/src/main/java/com/pontificia/remashorario/modules/studentGroup/StudentGroupEntity.java
+++ b/src/main/java/com/pontificia/remashorario/modules/studentGroup/StudentGroupEntity.java
@@ -1,6 +1,7 @@
 package com.pontificia.remashorario.modules.studentGroup;
 
 import com.pontificia.remashorario.modules.cycle.CycleEntity;
+import com.pontificia.remashorario.modules.period.PeriodEntity;
 import com.pontificia.remashorario.utils.abstractBase.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -17,4 +18,8 @@ public class StudentGroupEntity extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "cycle_id", referencedColumnName = "uuid")
     private CycleEntity cycle;
+
+    @ManyToOne
+    @JoinColumn(name = "period_id", referencedColumnName = "uuid", nullable = false)
+    private PeriodEntity period;
 }

--- a/src/main/java/com/pontificia/remashorario/modules/studentGroup/StudentGroupRepository.java
+++ b/src/main/java/com/pontificia/remashorario/modules/studentGroup/StudentGroupRepository.java
@@ -8,6 +8,6 @@ import java.util.UUID;
 @Repository
 public interface StudentGroupRepository extends BaseRepository<StudentGroupEntity> {
 
-    // Método para verificar si un grupo con un nombre dado ya existe para un ciclo específico
-    boolean existsByNameAndCycle_Uuid(String name, UUID cycleUuid);
+    // Método para verificar si un grupo con un nombre dado ya existe para un ciclo y periodo específicos
+    boolean existsByNameAndCycle_UuidAndPeriod_Uuid(String name, UUID cycleUuid, UUID periodUuid);
 }

--- a/src/main/java/com/pontificia/remashorario/modules/studentGroup/dto/StudentGroupRequestDTO.java
+++ b/src/main/java/com/pontificia/remashorario/modules/studentGroup/dto/StudentGroupRequestDTO.java
@@ -18,4 +18,7 @@ public class StudentGroupRequestDTO {
 
     @NotNull(message = "El UUID del ciclo es obligatorio")
     private UUID cycleUuid;
+
+    @NotNull(message = "El UUID del periodo es obligatorio")
+    private UUID periodUuid;
 }

--- a/src/main/java/com/pontificia/remashorario/modules/studentGroup/dto/StudentGroupResponseDTO.java
+++ b/src/main/java/com/pontificia/remashorario/modules/studentGroup/dto/StudentGroupResponseDTO.java
@@ -15,6 +15,8 @@ public class StudentGroupResponseDTO {
     private String name;
     private UUID cycleUuid; // Agregamos el UUID del ciclo
     private Integer cycleNumber; // Agregamos el número del ciclo para fácil visualización
+    private UUID periodUuid;
+    private String periodName;
     // Si realmente necesitas el DTO completo del ciclo, puedes usar:
     // private CycleResponseDTO cycle;
 }

--- a/src/main/java/com/pontificia/remashorario/modules/studentGroup/mapper/StudentGroupMapper.java
+++ b/src/main/java/com/pontificia/remashorario/modules/studentGroup/mapper/StudentGroupMapper.java
@@ -2,6 +2,8 @@ package com.pontificia.remashorario.modules.studentGroup.mapper;
 
 import com.pontificia.remashorario.modules.cycle.CycleEntity;
 import com.pontificia.remashorario.modules.cycle.CycleService;
+import com.pontificia.remashorario.modules.period.PeriodEntity;
+import com.pontificia.remashorario.modules.period.PeriodService;
 import com.pontificia.remashorario.modules.studentGroup.StudentGroupEntity;
 import com.pontificia.remashorario.modules.studentGroup.dto.StudentGroupRequestDTO;
 import com.pontificia.remashorario.modules.studentGroup.dto.StudentGroupResponseDTO;
@@ -14,10 +16,12 @@ import java.util.stream.Collectors;
 public class StudentGroupMapper {
 
     private final CycleService cycleService;
+    private final PeriodService periodService;
     // private final CareerMapper careerMapper; // Solo si CycleResponseDTO en StudentGroupResponseDTO anida CareerResponseDTO
 
-    public StudentGroupMapper(CycleService cycleService) { // Solo inyectar CycleService si CareerMapper no se necesita aquí
+    public StudentGroupMapper(CycleService cycleService, PeriodService periodService) {
         this.cycleService = cycleService;
+        this.periodService = periodService;
         // this.careerMapper = careerMapper; // Si descomentas lo de arriba, descomenta esto también
     }
 
@@ -47,6 +51,8 @@ public class StudentGroupMapper {
                 .name(entity.getName())
                 .cycleUuid(entity.getCycle() != null ? entity.getCycle().getUuid() : null)
                 .cycleNumber(entity.getCycle() != null ? entity.getCycle().getNumber() : null)
+                .periodUuid(entity.getPeriod() != null ? entity.getPeriod().getUuid() : null)
+                .periodName(entity.getPeriod() != null ? entity.getPeriod().getName() : null)
                 // .cycle(cycleResponseDTO) // Si decides usar el DTO completo
                 .build();
     }
@@ -71,6 +77,9 @@ public class StudentGroupMapper {
         CycleEntity cycle = cycleService.findCycleOrThrow(requestDTO.getCycleUuid());
         entity.setCycle(cycle);
 
+        PeriodEntity period = periodService.findPeriodOrThrow(requestDTO.getPeriodUuid());
+        entity.setPeriod(period);
+
         return entity;
     }
 
@@ -94,6 +103,12 @@ public class StudentGroupMapper {
                 (entity.getCycle() == null || !requestDTO.getCycleUuid().equals(entity.getCycle().getUuid()))) {
             CycleEntity newCycle = cycleService.findCycleOrThrow(requestDTO.getCycleUuid());
             entity.setCycle(newCycle);
+        }
+
+        if (requestDTO.getPeriodUuid() != null &&
+                (entity.getPeriod() == null || !requestDTO.getPeriodUuid().equals(entity.getPeriod().getUuid()))) {
+            PeriodEntity newPeriod = periodService.findPeriodOrThrow(requestDTO.getPeriodUuid());
+            entity.setPeriod(newPeriod);
         }
     }
 


### PR DESCRIPTION
## Summary
- introduce `Period` module with entity, repository, service, mapper, controller
- attach `Period` to `StudentGroup` and `ClassSession`
- update DTOs, mappers and services to handle periods
- ensure unique group names per cycle and period

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683cd1724d688330b47336541987dcca