### PR TITLE
Restrict teacher access

### DIFF
--- a/src/main/java/com/pontificia/remashorario/config/security/SecurityConfig.java
+++ b/src/main/java/com/pontificia/remashorario/config/security/SecurityConfig.java
@@ -34,6 +34,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/api/protected/**").hasRole("COORDINATOR")
+                        // Allow teachers to manage only their availability endpoints
+                        .requestMatchers("/api/protected/teachers/**/availabilities/**").hasRole("TEACHER")
+                        // Other protected endpoints are reserved for coordinators or assistants
+                        .requestMatchers("/api/protected/**").hasAnyRole("COORDINATOR", "ASSISTANT")
                         .anyRequest().authenticated()
                 )
                 .userDetailsService(userService)


### PR DESCRIPTION
## Summary
- limit teacher role to only teacher availability endpoints

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684273a1ce988330a50fd4a453b80d76